### PR TITLE
chore/update-prettier-hook

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,8 +1,4 @@
 {
-  "*/backend/**/*.ts": ["npm run format -w backend", "npm run lint:fix -w backend", "npm run test:staged -w backend"],
-  "*/frontend/**/*.{ts,tsx}": [
-    "npm run format -w frontend",
-    "npm run lint:fix -w frontend",
-    "npm run test:staged -w frontend"
-  ]
+  "*/backend/**/*.ts": ["prettier --write", "npm run lint:fix -w backend", "npm run test:staged -w backend"],
+  "*/frontend/**/*.{ts,tsx}": ["prettier --write", "npm run lint:fix -w frontend", "npm run test:staged -w frontend"]
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "scripts": {
     "start": "echo \"Error: no script defined\" && exit 1",
     "start:front": "npm run dev -w frontend",
-    "format": "prettier --write 'packages/**/*.{js,ts,tsx,css,md,json}' --config ./.prettierrc",
     "test": "jest",
     "prepare": "husky install"
   },

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0",
   "description": "A simple TypeScript application to manage internal feature and hotfix demands.",
   "scripts": {
-    "format": "prettier --write 'src/**/*.{js,ts,json}' --config ../../.prettierrc",
     "lint:fix": "npm run lint -- --fix",
     "lint": "eslint .",
     "test:coverage": "jest --runInBand --coverage",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -31,7 +31,6 @@
     "webpack-merge": "^5.8.0"
   },
   "scripts": {
-    "format": "prettier --write 'src/**/*.{js,ts,tsx,css,json}' --config ../../.prettierrc",
     "lint:fix": "npm run lint -- --fix",
     "lint": "eslint .",
     "dev:base": "webpack-dev-server --config webpack.dev.js",


### PR DESCRIPTION
What's changed:
- Fixed prettier hook by using it in lint-staged instead of a npm script. That will prevent the hook from failing due to running on all changed-files.